### PR TITLE
Fix updating issues

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "css": "style.css",
   "author": "Carmenta",
   "version": "0.1.0",
-  "homePage": "",
+  "homePage": "https://github.com/CarmentaGit/Carmy-InfoBoard",
   "auto_update": false,
   "minimum_client_version": "1.0.0"
 }
+


### PR DESCRIPTION
Fill in `homePage` in the manifest to fix any possible issues when updating the extension.

Also just generally helpful when using an extension manager extension that displays the homepage.
That way you don't need to dig through the ST discord server for the link again, should an issue arise.